### PR TITLE
Kube Deployment and expose through load balancer

### DIFF
--- a/kube/services.yml
+++ b/kube/services.yml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: community-web
+  labels:
+    app: community-web
+spec:
+  selector:
+    matchLabels:
+      app: community-web
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: community-web
+    spec:
+      containers:
+      - name: community-web
+        image: errrrk/community-web
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: community-loadbalancer
+spec:
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 0.0.0.0/0
+  ports:
+  - name: community-loadbalancer
+    port: 10000
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: community-web


### PR DESCRIPTION
Assumes Docker-for-Desktop for local development, since that's the only
local setup that supports Kube load balancers natively. Minikube for instance
requires NodePort or other workarounds.

local-motion/product#25