### PR TITLE
Kube Deployment and expose through load balancer

### DIFF
--- a/kube/loadbalancer.yml
+++ b/kube/loadbalancer.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: community-loadbalancer
+spec:
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 0.0.0.0/0
+  ports:
+  - name: community-loadbalancer
+    port: 10000
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: community-web

--- a/kube/services.yml
+++ b/kube/services.yml
@@ -23,19 +23,3 @@ spec:
             memory: 100Mi
         ports:
         - containerPort: 80
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: community-loadbalancer
-spec:
-  type: LoadBalancer
-  loadBalancerSourceRanges:
-  - 0.0.0.0/0
-  ports:
-  - name: community-loadbalancer
-    port: 10000
-    targetPort: 80
-    protocol: TCP
-  selector:
-    app: community-web


### PR DESCRIPTION
Assumes Docker-for-Desktop for local development, since that's the only
local setup that supports Kube load balancers natively. Minikube for instance
requires NodePort or other workarounds.

local-motion/product#25